### PR TITLE
Doesn't take the right argument to write the file in the dest folder

### DIFF
--- a/tasks/pure_grids.js
+++ b/tasks/pure_grids.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
         this.files.forEach(function (fileGroup) {
             var css = rework('').use(pureGrids.units(units, options));
 
-            grunt.file.write(fileGroup.dest, css.toString(options));
+            grunt.file.write(fileGroup.orig.src[0], css.toString(options));
             grunt.log.writeln('File "' + fileGroup.dest + '" created.');
         });
     });


### PR DESCRIPTION
I used this configuration , and when I used the grunt task, it wrote a file named dest at the same path than my gruntfile

```
  pure_grids: {
            dest : 'src/css/vendors/purecss/grids/tva-grid.less',
            options: {
                units: 24, //24-column grid
                mediaQueries: {
                    sm : 'screen and (min-width: 35.5em)', // 568px
                    med: 'screen and (min-width: 48em)',   // 768px
                    lrg: 'screen and (min-width: 58em)',   // 928px
                    xl : 'screen and (min-width: 75em)'    // 1200px
                }
            }
        }
```
