### PR TITLE
Clarified options.includeReducedFractions usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Determines whether or not each grid unit should have an accompanying `*width` va
 Type: `Boolean`
 Default value: `true`
 
-Determines whether or not the output should only include the reduced fractions. Setting this to `true` means that all grid classnames would be provided in their reduced form (ex: `.pure-u-md-2-4` would be renamed to `.pure-u-md-1-2`). Setting this to `false` will output class names in their regular **and** reduced fractional form.
+Determines whether or not the output should only include the reduced fractions. Setting this to `true` will output class names in their regular **and** reduced fractional form. Setting this to `false`  means that all grid classnames would be provided in their reduced form (ex: `.pure-u-md-2-4` would be renamed to `.pure-u-md-1-2`).
 
 #### options.decimals
 Type: `Integer`


### PR DESCRIPTION
I flipped the two sentences to match the `true`/`false` usage. Related: yahoo/grunt-pure-grids#8
